### PR TITLE
Generalisation work

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,15 +20,38 @@ In your peer boot-up namespace:
 
 ##### Write to Redis
 
+Example:
+
+```clojure
+{:onyx/name :out-to-redis
+ :onyx/plugin :onyx.plugin.redis/writer
+ :onyx/type :output
+ :onyx/medium :redis
+ :redis/host "127.0.0.1"
+ :redis/port 6379
+ :onyx/batch-size batch-size}
+```
+
+###### Attributes
+
 |key                           | type                 | description
 |------------------------------|----------------------|------------
 |`:redis/host`                 | `string`             | Redis hostname
 |`:redis/port`                 | `int`                | Redis port
-|`:redis/keystore`             |`keyword` or `string` | A Redis key to write a reference key for each output.
-|`:redis/read-timeout-ms`      |`int`                 | Time to wait (in ms) before giving up on trying to write to Redis.
+|`:redis/read-timeout-ms`      | `int`                | Time to wait (in ms) before giving up on trying to write to Redis.
 
+Segments should be supplied to the plugin in the form:
+```clojure
+{:op :sadd :key redis-key :value redis-value}
+```
 
-###### Inject Connection Spec lifecycle
+Where op is one of:
+```
+:sadd, :zadd, :lpush, :set
+```
+These correspond to their equivalent calls in carmine, see [documentation] (https://github.com/ptaoussanis/carmine/blob/master/src/commands/commands.list).
+
+##### Inject Connection Spec lifecycle
 
 Injects an carmine connection spec into the event map. Will also inject as an :onyx/fn param if :onyx/param? is true.
 
@@ -57,6 +80,8 @@ Alternatively, the conn that is created is placed under `:redis/conn` in the
 event map, for use within lifecycles e.g. :before-batch. Use in this way allows
 requests to be batched.
 
+Please see the Carmine documentation for examples for how to use Carmine.
+
 ##### Read Sets from Redis Input Plugin
 
 Catalog entry:
@@ -64,28 +89,17 @@ Catalog entry:
 ```clojure
 
 {:onyx/name :in-from-redis
-:onyx/plugin :onyx.plugin.redis/read-sets-from-redis
-:onyx/ident :redis/read-from-set
-:onyx/type :input
-:onyx/medium :redis
-:redis/host "127.0.0.1"
-:redis/port 6379
-:redis/keystore ::keystore
-:redis/step-size 5
-:onyx/batch-size batch-size
-:onyx/max-peers 1
-:onyx/doc "Reads segments via redis"}
+ :onyx/plugin :onyx.plugin.redis/read-sets-from-redis
+ :onyx/type :input
+ :onyx/medium :redis
+ :redis/host "127.0.0.1"
+ :redis/port 6379
+ :redis/keystore ::keystore
+ :redis/step-size 5
+ :onyx/batch-size batch-size
+ :onyx/max-peers 1
+ :onyx/doc "Reads segments via redis"}
 
-{:onyx/name :out-to-redis
-:onyx/plugin :onyx.plugin.redis/write-to-set
-:onyx/ident :redis/write-to-set
-:onyx/type :output
-:onyx/medium :redis
-:redis/key-prefix "new"
-:redis/host "127.0.0.1"
-:redis/port 6379
-:redis/keystore ::keystore-out
-:onyx/batch-size batch-size}
 ```
 
 Lifecycle entry:
@@ -95,8 +109,7 @@ Lifecycle entry:
   :lifecycle/calls :onyx.plugin.redis/reader-state-calls}]
 ```
 
-#### Attributes
-##### Read from Redis
+###### Attributes
 
 |key                           | type                 | description
 |------------------------------|----------------------|------------

--- a/README.md
+++ b/README.md
@@ -74,7 +74,6 @@ Lifecycle entry:
 |`:redis/host`                 | `string`             | Redis hostname
 |`:redis/port`                 | `int`                | Redis port
 |`:redis/keystore`             |`keyword` or `string` | A Redis key to write a reference key for each output.
-|`:redis/key-prefix`           |`str`                 | A prefix for each set key. Leave blank for update-in-place.
 |`:redis/read-timeout-ms`      |`int`                 | Time to wait (in ms) before giving up on trying to write to Redis.
 
 #### Contributing

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Onyx plugin for redis.
 In your project file:
 
 ```clojure
-[onyx-redis "0.7.0.2"]
+[onyx-redis "0.7.3.0"]
 ```
 
 In your peer boot-up namespace:

--- a/README.md
+++ b/README.md
@@ -18,7 +18,46 @@ In your peer boot-up namespace:
 
 #### Functions
 
-##### sample-entry
+##### Write to Redis
+
+|key                           | type                 | description
+|------------------------------|----------------------|------------
+|`:redis/host`                 | `string`             | Redis hostname
+|`:redis/port`                 | `int`                | Redis port
+|`:redis/keystore`             |`keyword` or `string` | A Redis key to write a reference key for each output.
+|`:redis/read-timeout-ms`      |`int`                 | Time to wait (in ms) before giving up on trying to write to Redis.
+
+
+###### Inject Connection Spec lifecycle
+
+Injects an carmine connection spec into the event map. Will also inject as an :onyx/fn param if :onyx/param? is true.
+
+```clojure
+{:lifecycle/task :use-redis-task
+ :lifecycle/calls :onyx.plugin.redis/reader-conn-spec
+ :redis/host redis-hostname
+ :redis/port redis-port
+ :redis/read-timeout-ms <<optional-timeout>>
+ :onyx/param? true
+ :lifecycle/doc "Initialises redis conn spec into event map, or as a :onyx.core/param"}
+```
+
+When used with task :use-redis-task and with :onyx/param? true, you can use it from your function e.g.
+
+```clojure
+(ns your.ns
+  (:require [taoensso.carmine :as car :refer (wcar)]))
+
+(defn use-redis-task-fn [conn segment]
+  (wcar conn
+        [(car/smembers (:key segment)])))
+```
+
+Alternatively, the conn that is created is placed under `:redis/conn` in the
+event map, for use within lifecycles e.g. :before-batch. Use in this way allows
+requests to be batched.
+
+##### Read Sets from Redis Input Plugin
 
 Catalog entry:
 
@@ -66,15 +105,6 @@ Lifecycle entry:
 |`:redis/keystore`             |`keyword` or `string` | A Redis [list](http://redis.io/topics/data-types) containing each the keys of each set the plugin is concerned with
 |`:redis/step-size`            |`int`                 | The step granularity to batch requests to Redis. defaults to 10
 |`:redis/read-timeout-ms`      |`int`                 | Time to wait (in ms) before giving up on trying to read from Redis.
-
-##### Write to Redis
-
-|key                           | type                 | description
-|------------------------------|----------------------|------------
-|`:redis/host`                 | `string`             | Redis hostname
-|`:redis/port`                 | `int`                | Redis port
-|`:redis/keystore`             |`keyword` or `string` | A Redis key to write a reference key for each output.
-|`:redis/read-timeout-ms`      |`int`                 | Time to wait (in ms) before giving up on trying to write to Redis.
 
 #### Contributing
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,26 @@
+dependencies:
+  override:
+    - echo '{:user {:plugins [[lein-voom "0.1.0-20150822_000839-g763d315"]]}}' > ~/.lein/profiles.clj
+    - lein voom build-deps
+    - ./scripts/start_redis.sh
+
+test:
+  override:
+    - lein with-profile dev,circle-ci midje:
+        timeout: 480 
+
+machine:
+  java:
+    version: oraclejdk8
+  services:
+    - docker
+
+#notify:
+#  webhooks:
+#    - url: https://webhooks.gitter.im/e/7f6cadb429def50c94a2
+
+#deployment:
+#  update-projects:
+#    branch: master
+#    commands:
+#      - lein deploy

--- a/circle.yml
+++ b/circle.yml
@@ -2,7 +2,7 @@ dependencies:
   override:
     - echo '{:user {:plugins [[lein-voom "0.1.0-20150822_000839-g763d315"]]}}' > ~/.lein/profiles.clj
     - lein voom build-deps
-    - ./scripts/start_redis.sh
+      #    - ./scripts/start_redis.sh
 
 test:
   override:

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject onyx-redis "0.7.0.4"
+(defproject onyx-redis "0.7.3.0"
   :description "Onyx plugin for redis"
   :url "FIX ME"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.7.0"]
-                 [org.onyxplatform/onyx "0.7.4-SNAPSHOT"]
+                 [org.onyxplatform/onyx "0.7.3"]
                  [com.taoensso/carmine "2.11.1" :exclusions [com.taoensso/timbre]]
                  [org.clojure/core.async "0.1.346.0-17112a-alpha"]]
   :profiles {:dev {:dependencies [[midje "1.7.0"]]

--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.7.0"]
-                 [org.onyxplatform/onyx "0.7.0"]
+                 [org.onyxplatform/onyx "0.7.3"]
                  [com.taoensso/carmine "2.11.1" :exclusions [com.taoensso/timbre]]
                  [org.clojure/core.async "0.1.346.0-17112a-alpha"]]
   :profiles {:dev {:dependencies [[midje "1.7.0"]]

--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.7.0"]
-                 [org.onyxplatform/onyx "0.7.3"]
+                 [org.onyxplatform/onyx "0.7.4-SNAPSHOT"]
                  [com.taoensso/carmine "2.11.1" :exclusions [com.taoensso/timbre]]
                  [org.clojure/core.async "0.1.346.0-17112a-alpha"]]
   :profiles {:dev {:dependencies [[midje "1.7.0"]]

--- a/project.clj
+++ b/project.clj
@@ -6,6 +6,10 @@
   :dependencies [[org.clojure/clojure "1.7.0"]
                  [org.onyxplatform/onyx "0.7.0"]
                  [com.taoensso/carmine "2.11.1" :exclusions [com.taoensso/timbre]]
-                 [org.clojure/core.async "0.1.346.0-17112a-alpha"]
-                 [midje "1.7.0"]]
+                 [org.clojure/core.async "0.1.346.0-17112a-alpha"]]
+  :profiles {:dev {:dependencies [[midje "1.7.0"]]
+                   :plugins [[lein-midje "3.1.3"]
+                             [lein-set-version "0.4.1"]
+                             [lein-pprint "1.1.1"]]}
+             :circle-ci {:jvm-opts ["-Xmx4g"]}}
   :jvm-opts ["-XX:-OmitStackTraceInFastThrow"])

--- a/scripts/start_redis.sh
+++ b/scripts/start_redis.sh
@@ -1,0 +1,3 @@
+#!/bin/sh -x
+IP=$(/sbin/ifconfig eth0 | grep 'inet addr:' | cut -d: -f2 | awk '{ print $1}')
+docker run -d -p 4334-4336:4334-4336 -e ALT_HOST=$IP --name datomic-free akiel/datomic-free

--- a/scripts/start_redis.sh
+++ b/scripts/start_redis.sh
@@ -1,3 +1,2 @@
 #!/bin/sh -x
-IP=$(/sbin/ifconfig eth0 | grep 'inet addr:' | cut -d: -f2 | awk '{ print $1}')
-docker run -d -p 4334-4336:4334-4336 -e ALT_HOST=$IP --name datomic-free akiel/datomic-free
+docker run --name redis_container -d redis

--- a/src/onyx/plugin/redis.clj
+++ b/src/onyx/plugin/redis.clj
@@ -138,7 +138,7 @@
                       conn keystore pending-messages
                       drained? step-size)))
 
-(defrecord RedisSetWriter [conn keystore prefix]
+(defrecord RedisWriter [conn keystore prefix]
   p-ext/Pipeline
   (read-batch [_ event]
     (onyx.peer.function/read-batch event))
@@ -155,7 +155,7 @@
   (seal-resource [_ _]
     {}))
 
-(defn write-to-set [pipeline-data]
+(defn write [pipeline-data]
   (let [catalog-entry (:onyx.core/task-map pipeline-data)
         keystore      (:redis/keystore catalog-entry)
         conn          {:spec {:host (:redis/host catalog-entry)
@@ -163,7 +163,7 @@
                               :read-timeout-ms (or (:redis/read-timeout-ms catalog-entry)
                                                    4000)}}
         prefix        (or (:redis/key-prefix catalog-entry) nil)]
-    (->RedisSetWriter conn keystore prefix)))
+    (->RedisWriter conn keystore prefix)))
 
 (def reader-state-calls
   {:lifecycle/before-task-start inject-pending-state})

--- a/src/onyx/plugin/redis.clj
+++ b/src/onyx/plugin/redis.clj
@@ -24,10 +24,10 @@
 (def reader-conn-spec
   {:lifecycle/before-task-start inject-conn-spec})
 
-(defrecord Ops [sadd lpush zadd])
+(defrecord Ops [sadd lpush zadd set])
 
 (def operations 
-  (->Ops car/sadd car/lpush car/zadd))
+  (->Ops car/sadd car/lpush car/zadd car/set))
 
 (defrecord RedisWriter [conn keystore]
   p-ext/Pipeline

--- a/src/onyx/plugin/redis.clj
+++ b/src/onyx/plugin/redis.clj
@@ -58,7 +58,8 @@
             @return)))))
 
 (defn inject-pending-state [event lifecycle]
-  (let [task     (:onyx.core/task-map event)
+  (let [pipeline (:onyx.core/pipeline event)
+        task     (:onyx.core/task-map event)
         host     (:redis/host task)
         port     (:redis/port task)
         keystore (:redis/keystore task)]
@@ -66,8 +67,8 @@
       (throw (Exception. "Onyx-Redis can not run with :onyx/max-peers greater than 1")))
     {:redis/conn             {:spec {:host host :port port} :pool nil}
      :redis/keystore         keystore
-     :redis/drained?         (atom false)
-     :redis/pending-messages (atom {})}))
+     :redis/drained?         (:drained? pipeline)
+     :redis/pending-messages (:pending-messages pipeline)}))
 
 (defrecord RedisSetReader [max-pending batch-size batch-timeout
                            conn keystore pending-messages

--- a/test/onyx/plugin/redis_lifecycle_test.clj
+++ b/test/onyx/plugin/redis_lifecycle_test.clj
@@ -1,0 +1,141 @@
+(ns onyx.plugin.redis-lifecycle-test
+  (:require [onyx.peer.pipeline-extensions :as p-ext]
+            [onyx.plugin.redis :refer :all]
+            [onyx.plugin.core-async :refer [take-segments!]]
+            [midje.sweet :refer :all]
+            [taoensso.timbre :refer [info]]
+            [taoensso.carmine :as car :refer [wcar]]
+            [clojure.core.async :as async :refer [chan <!! >!!]]
+            [onyx.api]))
+
+(def id (java.util.UUID/randomUUID))
+
+(def env-config
+  {:zookeeper/address "127.0.0.1:2188"
+   :zookeeper/server? true
+   :zookeeper.server/port 2188
+   :onyx/id id})
+
+(def peer-config
+  {:zookeeper/address "127.0.0.1:2188"
+   :onyx.peer/job-scheduler :onyx.job-scheduler/greedy
+   :onyx.messaging/impl :core.async
+   :onyx.messaging/bind-addr "localhost"
+   :onyx/id id})
+
+(def env (onyx.api/start-env env-config))
+
+(def peer-group (onyx.api/start-peer-group peer-config))
+
+(def n-messages (rand-int 1000))
+
+(def batch-size 8)
+
+(def redis-conn {:spec {:host "127.0.0.1"}})
+
+
+;;;;; Load up the redis with test data
+;;;;;
+;;;;;
+(doseq [n (range n-messages)]
+  (wcar redis-conn
+        (car/lpush ::some-key n)))
+
+(defn my-lookup [conn segment]
+  {:results (wcar conn
+                  (car/lrange (:key segment) 0 1000))})
+
+(def catalog
+  [{:onyx/name :in
+    :onyx/plugin :onyx.plugin.core-async/input
+    :onyx/type :input
+    :onyx/medium :core.async
+    :onyx/batch-size batch-size
+    :onyx/max-peers 1
+    :onyx/doc "Reads segments via core async"}
+
+   {:onyx/name :lookup
+    :onyx/fn ::my-lookup
+    :onyx/type :function
+    :onyx/batch-size batch-size}
+
+   {:onyx/name :out
+    :onyx/plugin :onyx.plugin.core-async/output
+    :onyx/ident :core.async/write-to-chan
+    :onyx/type :output
+    :onyx/medium :core.async
+    :onyx/batch-size batch-size
+    :onyx/doc ""
+    :onyx/max-peers 1}])
+
+(def workflow
+  [[:in :lookup]
+   [:lookup :out]])
+
+(def in-chan (chan 1000))
+
+(>!! in-chan {:key ::some-key})
+(>!! in-chan :done)
+
+(def out-chan (async/chan 1000))
+
+(defn inject-reader-ch [event lifecycle]
+  {:core.async/chan in-chan})
+
+(def in-lifecycle
+  {:lifecycle/before-task-start inject-reader-ch})
+
+(defn inject-writer-ch [event lifecycle]
+  {:core.async/chan out-chan})
+
+(def out-lifecycle
+  {:lifecycle/before-task-start inject-writer-ch})
+
+(def lifecycles
+  [{:lifecycle/task :in
+    :lifecycle/calls ::in-lifecycle}
+   {:lifecycle/task :in
+    :lifecycle/calls :onyx.plugin.core-async/reader-calls}
+
+   {:lifecycle/task :lookup
+    :lifecycle/calls :onyx.plugin.redis/reader-conn-spec
+    :redis/host "localhost"
+    :redis/port 6379
+    :onyx/param? true
+    :lifecycle/doc "Initialises redis conn spec into event map, or as a :onyx.core/param"}
+
+   {:lifecycle/task :out
+    :lifecycle/calls ::out-lifecycle}
+   {:lifecycle/task :out
+    :lifecycle/calls :onyx.plugin.core-async/writer-calls}])
+
+(def v-peers (onyx.api/start-peers 3 peer-group))
+
+(def job-id
+  (:job-id
+   (onyx.api/submit-job
+    peer-config
+    {:catalog catalog
+     :workflow workflow
+     :lifecycles lifecycles
+     :task-scheduler :onyx.task-scheduler/balanced})))
+
+(onyx.api/await-job-completion peer-config job-id)
+
+(doseq [v-peer v-peers]
+  (onyx.api/shutdown-peer v-peer))
+
+(onyx.api/shutdown-peer-group peer-group)
+
+(onyx.api/shutdown-env env)
+
+(def results (take-segments! out-chan))
+
+(fact results => [{:results (map str (reverse (range n-messages)))}
+                  :done])
+
+(fact (wcar redis-conn
+            (car/flushall)
+            (car/flushdb)) => ["OK" "OK"])
+
+

--- a/test/onyx/plugin/redis_writer_test.clj
+++ b/test/onyx/plugin/redis_writer_test.clj
@@ -1,0 +1,115 @@
+(ns onyx.plugin.redis-writer-test
+  (:require [onyx.peer.pipeline-extensions :as p-ext]
+            [onyx.plugin.redis :refer :all]
+            [clojure.core.async :refer [chan go-loop >!! <!! <! close!]]
+            [onyx.plugin.core-async :refer [take-segments!]]
+            [midje.sweet :refer :all]
+            [taoensso.carmine :as car :refer [wcar]]
+            [clojure.core.async :as async :refer [chan <!! >!!]]
+            [onyx.api]))
+
+(def id (java.util.UUID/randomUUID))
+
+(def env-config
+  {:zookeeper/address "127.0.0.1:2188"
+   :zookeeper/server? true
+   :zookeeper.server/port 2188
+   :onyx/id id})
+
+(def peer-config
+  {:zookeeper/address "127.0.0.1:2188"
+   :onyx.peer/job-scheduler :onyx.job-scheduler/greedy
+   :onyx.messaging/impl :core.async
+   :onyx.messaging/bind-addr "localhost"
+   :onyx/id id})
+
+(def env (onyx.api/start-env env-config))
+
+(def peer-group (onyx.api/start-peer-group peer-config))
+
+(def n-messages (rand-int 1000))
+
+(def batch-size 8)
+
+(def redis-conn {:spec {:host "127.0.0.1"}})
+
+(def messages
+  [{:op :sadd :key "cyclists" :value {:name "John" :age 20}}
+   {:op :sadd :key "runners" :value {:name "Mike" :age 24}}
+   {:op :sadd :key "cyclists" :value {:name "Jane" :age 25}}
+   {:op :sadd :key "runners" :value {:name "Mike" :age 24}}
+   :done]) 
+
+(def in-chan (chan (count messages)))
+
+(doseq [m messages]
+  (>!! in-chan m))
+
+(close! in-chan)
+
+(defn inject-in-ch [event lifecycle]
+  {:core.async/chan in-chan})
+
+(def in-calls
+  {:lifecycle/before-task-start inject-in-ch})
+
+(def lifecycles
+  [{:lifecycle/task :in
+    :lifecycle/calls ::in-calls}
+   {:lifecycle/task :in
+    :lifecycle/calls :onyx.plugin.core-async/reader-calls}])
+
+(def catalog
+  [{:onyx/name :in
+    :onyx/plugin :onyx.plugin.core-async/input
+    :onyx/type :input
+    :onyx/medium :core.async
+    :onyx/batch-size batch-size
+    :onyx/max-peers 1
+    :onyx/doc "Reads segments via redis"}
+
+   {:onyx/name :out-redis
+    :onyx/plugin :onyx.plugin.redis/writer
+    :onyx/type :output
+    :onyx/medium :redis
+    :redis/key-prefix "initial"
+    :redis/host "127.0.0.1"
+    :redis/port 6379
+    :redis/keystore ::keystore-out
+    :onyx/batch-size batch-size}])
+
+(def workflow
+  [[:in :out-redis]])
+
+(def v-peers (onyx.api/start-peers 2 peer-group))
+
+(def job-id
+  (:job-id
+   (onyx.api/submit-job
+    peer-config
+    {:catalog catalog
+     :workflow workflow
+     :lifecycles lifecycles
+     :task-scheduler :onyx.task-scheduler/balanced})))
+
+(onyx.api/await-job-completion peer-config job-id)
+
+(doseq [v-peer v-peers]
+  (onyx.api/shutdown-peer v-peer))
+
+(onyx.api/shutdown-peer-group peer-group)
+
+(onyx.api/shutdown-env env)
+
+(fact (sort-by :name 
+               (car/wcar redis-conn
+                         (set (car/smembers (car/key "initial" "cyclists")))))
+      => 
+      [{:name "Jane" :age 25}
+       {:name "John" :age 20}])
+
+(fact (sort-by :name 
+               (car/wcar redis-conn
+                         (set (car/smembers (car/key "initial" "runners")))))
+      => 
+      [{:name "Mike" :age 24}])

--- a/test/onyx/plugin/redis_writer_test.clj
+++ b/test/onyx/plugin/redis_writer_test.clj
@@ -72,10 +72,8 @@
     :onyx/plugin :onyx.plugin.redis/writer
     :onyx/type :output
     :onyx/medium :redis
-    :redis/key-prefix "initial"
     :redis/host "127.0.0.1"
     :redis/port 6379
-    :redis/keystore ::keystore-out
     :onyx/batch-size batch-size}])
 
 (def workflow
@@ -103,13 +101,13 @@
 
 (fact (sort-by :name 
                (car/wcar redis-conn
-                         (set (car/smembers (car/key "initial" "cyclists")))))
+                         (set (car/smembers "cyclists"))))
       => 
       [{:name "Jane" :age 25}
        {:name "John" :age 20}])
 
 (fact (sort-by :name 
                (car/wcar redis-conn
-                         (set (car/smembers (car/key "initial" "runners")))))
+                         (set (car/smembers "runners"))))
       => 
       [{:name "Mike" :age 24}])


### PR DESCRIPTION
Hi @gardnervickers, I've been trying to make the plugin a bit more general by making a few changes.
Firstly, the new output plugin now takes the results to write out in segment form. Then if you need to write  a bunch of values at the same time you just transform them in your incoming :onyx/fn.

See: https://github.com/gardnervickers/onyx-redis/compare/master...lbradstreet:master#diff-1213311ca373fccd3874bd98730605f9R55

This makes the writer function more general.

Second, I've added a lifecycle to inject a conn into your fn params, and/or the event map (for use in lifecycles). This will make it simpler to use wcar from your functions.

Lastly (but not implemented yet), I'll try to modify the input plugin to simply read a set, or read a list, etc, which can then be mapped into reading more values in a downstream task. This will allow you to do what you've done in the set reader while keeping the plugin pretty general.

I've also made it run on circleci, but you won't be able to see it unless you add your project via circle.

I'd love to hear what you think,

Cheers

Lucas